### PR TITLE
Add package 'gettext-base'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 RUN set -eux; \
 # Install base packages
 	apt-get update -yqq; \
-	apt-get install -yqq apt-utils wget ca-certificates git zip unzip tar lsb-release gnupg; \
+	apt-get install -yqq apt-utils wget ca-certificates git zip unzip tar lsb-release gnupg gettext-base; \
 # Create storage locations
 	mkdir -p "$NEO_SDK_HOME"; \
 	mkdir -p "$MTA_BUILDER_HOME"; \


### PR DESCRIPTION
[GNU gettext](https://www.gnu.org/software/gettext/) is a package containing various commands for localization and text parsing; Very useful for parsing e.g. config files is the included command envsubst.

gettext adds ~5KB to the docker image