### PR TITLE
Update NEO SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 # Download URLs
-ENV NEO_SDK_URL      "https://tools.hana.ondemand.com/sdk/neo-java-web-sdk-3.145.7.zip"
+ENV NEO_SDK_URL      "https://tools.hana.ondemand.com/sdk/neo-java-web-sdk-3.154.5.zip"
 ENV NODEJS_URL       "https://deb.nodesource.com/setup_12.x"
 
 # Storage locations


### PR DESCRIPTION
Hi Nils,

_Warning: Your SDK version "3.145.7" is no longer supported. The latest version is "3.154.5" and upgrade is highly recommended._

Regards,
Timo