### PR TITLE
Dockerfile: Resolve some deprecations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV NEO_SDK_VERSION    "4.59.9.1"
 
 # Download URLs
 ENV NEO_SDK_URL        "https://tools.hana.ondemand.com/sdk/neo-java-web-sdk-$NEO_SDK_VERSION.zip"
-ENV NODEJS_URL         "https://deb.nodesource.com/setup_16.x"
 # Storage locations
 ENV NEO_SDK_HOME       "/opt/neo-sdk"
 ENV MTA_BUILDER_HOME   "/opt/mta-builder"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM ubuntu:22.04
 
-# Download URLs
-ENV NEO_SDK_URL      "https://tools.hana.ondemand.com/sdk/neo-java-web-sdk-3.186.6.zip"
-ENV NODEJS_URL       "https://deb.nodesource.com/setup_16.x"
+# Versions
+ENV NODE_VERSION       "18"
+ENV SAPMACHINE_VERSION "11"
+ENV NEO_SDK_VERSION    "4.59.9.1"
 
+# Download URLs
+ENV NEO_SDK_URL        "https://tools.hana.ondemand.com/sdk/neo-java-web-sdk-$NEO_SDK_VERSION.zip"
+ENV NODEJS_URL         "https://deb.nodesource.com/setup_16.x"
 # Storage locations
-ENV NEO_SDK_HOME     "/opt/neo-sdk"
-ENV MTA_BUILDER_HOME "/opt/mta-builder"
+ENV NEO_SDK_HOME       "/opt/neo-sdk"
+ENV MTA_BUILDER_HOME   "/opt/mta-builder"
 
 ENV JAVA_HOME "/usr/lib/jvm/sapmachine-11"
 ENV PATH="${JAVA_HOME}/bin:${NEO_SDK_HOME}/tools:${PATH}"
@@ -30,71 +34,70 @@ LABEL org.opencontainers.image.authors       "https://github.com/Cyclenerd/scp-t
 LABEL org.opencontainers.image.documentation "https://github.com/Cyclenerd/scp-tools-gitlab/blob/master/README.md"
 LABEL org.opencontainers.image.source        "https://github.com/Cyclenerd/scp-tools-gitlab"
 
-RUN set -eux; \
+RUN set -eux && \
 # Install base packages
-	apt-get update -yqq; \
-	apt-get install -yqq apt-utils build-essential wget ca-certificates git zip unzip tar lsb-release gnupg gettext-base python3-pip; \
+	apt-get update -yq && \
+	apt-get install -yq apt-utils build-essential wget ca-certificates git zip unzip tar lsb-release gnupg gettext-base python3-pip && \
 # Create storage locations
-	mkdir -p "$NEO_SDK_HOME"; \
-	mkdir -p "$MTA_BUILDER_HOME"; \
-# Install Node.js
-	wget -nv --output-document="$HOME/nodejs_setup.sh" "$NODEJS_URL"; \
-	bash "$HOME/nodejs_setup.sh"; \
-	apt-get update -yqq; \
-	apt-get install -yqq nodejs; \
-	rm "$HOME/nodejs_setup.sh"; \
+	mkdir -p "$NEO_SDK_HOME" && \
+	mkdir -p "$MTA_BUILDER_HOME" && \
+# Install Node.js \
+    wget -q -O - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION?}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
+	apt-get update -yq && \
+	apt-get install -yq nodejs && \
 # Install Node.js packages (https://www.npmjs.com/package)
-	npm install @ui5/cli -g; \
-	npm install grunt-cli -g; \
-	npm install gulp-cli -g; \
-	npm install showdown -g; \
-	npm install eslint -g; \
-	npm install eslint-plugin-ui5 -g; \
-	npm install eslint-config-ui5 -g; \
+	npm install @ui5/cli -g && \
+	npm install grunt-cli -g && \
+	npm install gulp-cli -g && \
+	npm install showdown -g && \
+	npm install eslint -g && \
+	npm install eslint-plugin-ui5 -g && \
+	npm install eslint-config-ui5 -g && \
 # Install SapMachine JDK
-	wget -q -O - https://dist.sapmachine.io/debian/sapmachine.key | apt-key add -; \
-	echo "deb http://dist.sapmachine.io/debian/amd64/ ./" | tee /etc/apt/sources.list.d/sapmachine.list; \
-	apt-get update -yqq; \
-	apt-get install -yqq sapmachine-11-jdk; \
+    wget -q -O - https://dist.sapmachine.io/debian/sapmachine.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/sapmachine.gpg && \
+	echo "deb [signed-by=/etc/apt/trusted.gpg.d/sapmachine.gpg] http://dist.sapmachine.io/debian/amd64/ ./" > /etc/apt/sources.list.d/sapmachine.list && \
+	apt-get update -yq && \
+	apt-get install -yq "sapmachine-${SAPMACHINE_VERSION?}-jdk" && \
 # Install Cloud Foundry CLI
-	wget -q -O - "https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key" | apt-key add -; \
-	echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list; \
-	apt-get update -yqq; \
-	apt-get install -yqq cf-cli;\
+    wget -q -O - "https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key" | gpg --dearmor -o /etc/apt/trusted.gpg.d/cloudfoundry.gpg && \
+	echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry.gpg] https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list && \
+	apt-get update -yq && \
+	apt-get install -yq cf-cli && \
 # ...so that "cf deploy" is available
-	cf install-plugin multiapps -f;\ 
+	cf install-plugin multiapps -f && \
 # Install SAP Cloud Platform Neo Environment SDK (https://tools.hana.ondemand.com/#cloud)
-	wget -nv --output-document="$HOME/neo-java-web-sdk.zip" --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" "$NEO_SDK_URL"; \
-	unzip -q -o "$HOME/neo-java-web-sdk.zip" -d "$NEO_SDK_HOME"; \
-	rm "$HOME/neo-java-web-sdk.zip"; \
+	wget -nv --output-document="$HOME/neo-java-web-sdk.zip" --no-cookies --header "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" "$NEO_SDK_URL" && \
+	unzip -q -o "$HOME/neo-java-web-sdk.zip" -d "$NEO_SDK_HOME" && \
+	rm "$HOME/neo-java-web-sdk.zip" && \
 # Install mbt / Currently there is a bug in binwrap, so we have to use this workaround ( https://github.com/avh4/binwrap/issues/21 ) 
-	npm install mbt -g --ignore-scripts; \ 
-	cd /usr/lib/node_modules/mbt/; \
-	chmod -R 777 .; \
-	npm install; \
+	npm install mbt -g --ignore-scripts && \
+	cd /usr/lib/node_modules/mbt/ && \
+	chmod -R 777 . && \
+	npm install && \
 # MkDocs
-	pip3 install mkdocs ; \
-	pip3 install mkdocs-material; \
-	pip3 install mkdocs-minify-plugin; \
+	pip3 install mkdocs  && \
+	pip3 install mkdocs-material && \
+	pip3 install mkdocs-minify-plugin && \
 # Basic smoke test
-	lsb_release -a; \
-	uname -a; \
-	wget --version | head -1; \
-	zip -v | head -2; \
-	unzip -v | head -1; \
-	tar --version | head -1; \
-	envsubst --version | head -1; \
-	node --version; \
-	npm --version; \
-	java --version; \
-	python3 --version; \
-	cf --version; \
-	neo.sh version; \
-	mbt --version; \
-	mkdocs --version; \
+	lsb_release -a && \
+	uname -a && \
+	wget --version | head -1 && \
+	zip -v | head -2 && \
+	unzip -v | head -1 && \
+	tar --version | head -1 && \
+	envsubst --version | head -1 && \
+	node --version && \
+	npm --version && \
+	java --version && \
+	python3 --version && \
+	cf --version && \
+	neo.sh version && \
+	mbt --version && \
+	mkdocs --version && \
 # Delete cache
-	pip3 cache purge; \
-	apt-get clean; \
+	pip3 cache purge && \
+	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
 # If you're reading this and have any feedback on how this image could be


### PR DESCRIPTION
### List of changes:

- Migrate from deprecated nodejs installer to officially endorsed method (nodesource installer)
- Prevent silently ignoring errors by using '&&' for command chaining instead of ';'
- Stop using the deprecated tool apt-key
- Update neo sdk
- Make sapmachine version easier to configure

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/scp-tools-gitlab/blob/master/CONTRIBUTING.md)

## Notes

Currently, the build will fail, because of [an upstream issue](https://github.com/cloudfoundry/cli/issues/2571). I tested it locally, by patching the following two lines in Dockerfile (**This  workaround is insecure and should not be used for building production images!**):

```diff
diff --git a/Dockerfile b/Dockerfile
index 3a8ea40..519acec 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,5 @@
 # Install Cloud Foundry CLI
     wget -q -O - "https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key" | gpg --dearmor -o /etc/apt/trusted.gpg.d/cloudfoundry.gpg && \
        echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloudfoundry.gpg] https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list && \
-       apt-get update -yq && \
-       apt-get install -yq cf-cli && \
+       apt-get update -o Acquire::AllowInsecureRepositories=true -yq && \
+       apt-get install --allow-unauthenticated -yq cf-cli && \
```
